### PR TITLE
Removing the master-slave phrasing

### DIFF
--- a/Linux_Tricks/Ansible_how_to.py
+++ b/Linux_Tricks/Ansible_how_to.py
@@ -268,7 +268,7 @@ UserKnownHostsFile=/dev/null
 ServerAliveInterval 120
 ServerAliveCountMax 2
 ControlPath ~/.ssh/master-%r@%h:%p
-ControlMaster auto
+ControlMain auto
 ControlPersist 60s
 }}}
 

--- a/Linux_Tricks/Linux_TIPS.py
+++ b/Linux_Tricks/Linux_TIPS.py
@@ -1045,7 +1045,7 @@ sudo apt-get install lightdm gnome-terminal synaptic && sudo apt-get install --n
 ## ubuntu live cd 
 http://www.instalinux.com/cgi-bin/debian_image.cgi
 http://mijyn.github.io/relinux/#download
-http://www.remastersys.com/
+http://www.remainsys.com/
 
 # relinux how to 
 sudo add-apt-repository ppa:relinux-dev/testing
@@ -1056,8 +1056,8 @@ sudo apt-get update
 
 Paste below two lines.
 
-# Remastersys
-deb http://www.remastersys.com/repository lucid/
+# Remainsys
+deb http://www.remainsys.com/repository lucid/
 
 2.Update recently added source list by executing
 
@@ -1065,9 +1065,9 @@ sudo apt-get update
 
 3.Type
 
-sudo apt-get install remastersys
+sudo apt-get install remainsys
 
-You have successfully installed remastersys on your machine.
+You have successfully installed remainsys on your machine.
 
 
 

--- a/Linux_Tricks/Moinmoin_wiki_how_to.py
+++ b/Linux_Tricks/Moinmoin_wiki_how_to.py
@@ -50,7 +50,7 @@ plugin = python27
 chdir = /var/www/moinmoin/wiki
 wsgi-file = /var/www/moinmoin/wiki/moin.wsgi
 
-master
+main
 workers = 2
 max-requests = 20
 harakiri = 60

--- a/Linux_Tricks/Pass_how_to.py
+++ b/Linux_Tricks/Pass_how_to.py
@@ -22,7 +22,7 @@ $ gpg --list-keys
 
 $ pass init 74D27AA9
 Password store initialized for 74D27AA9
-[master 6f5097d] Set GPG id to 74D27AA9.
+[main 6f5097d] Set GPG id to 74D27AA9.
 1 file changed, 1 insertion(+), 1 deletion(-)
 
 $ gpg --edit-key 74D27AA9
@@ -63,7 +63,7 @@ Reinitialized existing Git repository in /home/merlyn/.password-store/.git/
 $ pass insert Gmail/bbbcccbobobo@gmail.com
 Enter password for Gmail/bbbcccbobobo@gmail.com: 
 Retype password for Gmail/bbbcccbobobo@gmail.com: 
-[master cf17704] Add given password for Gmail/bbbcccbobobo@gmail.com to store.
+[main cf17704] Add given password for Gmail/bbbcccbobobo@gmail.com to store.
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 Gmail/bbbcccbobobo@gmail.com.gpg
 

--- a/Linux_Tricks/Salt_how_to.py
+++ b/Linux_Tricks/Salt_how_to.py
@@ -23,16 +23,16 @@
 install Salt at Gentoo 
 emerge slat
 
-2, Start slat master server
-#/etc/salt/master
+2, Start slat main server
+#/etc/salt/main
 # The address of the interface to bind to:
 interface: 0.0.0.0
 
-/etc/init.d/slat-master start
+/etc/init.d/slat-main start
 
 3, install slat-minion Client
 # sed '/^#/d;/^$/d' /etc/salt/minion 
-master: 192.168.1.111
+main: 192.168.1.111
 
 /etc/init.d/slat-minion start
 
@@ -106,7 +106,7 @@ brightmoon:
         old:
 # Windows support
 # install Client!!!
-Salt-Minion-0.17.0-Setup-amd64.exe /S /master=yoursaltmaster /minion-name=yourminionname
+Salt-Minion-0.17.0-Setup-amd64.exe /S /main=yoursaltmain /minion-name=yourminionname
 
 brightmoon ~ #  salt 'windows2003-test01' user.list_users
 windows2003-test01:
@@ -132,7 +132,7 @@ salt '*' system.shutdown_hard
 # Salt group support
  Node Groups
        Often the convenience of having a predefined group of minions to execute targets on is desired. This can be accomplished  with  the  new  nodegroups
-       feature. Nodegroups allow for predefined compound targets to be declared in the master configuration file:
+       feature. Nodegroups allow for predefined compound targets to be declared in the main configuration file:
 
           nodegroups:
             group1: 'L@foo.domain.com,bar.domain.com,baz.domain.com and bl*.domain.com'


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.